### PR TITLE
Improved remote branch implements

### DIFF
--- a/ObjectiveGit/GTBranch.m
+++ b/ObjectiveGit/GTBranch.m
@@ -193,7 +193,12 @@
 }
 
 - (BOOL)updateTrackingBranch:(GTBranch *)trackingBranch error:(NSError **)error {
-	int result = git_branch_set_upstream(self.reference.git_reference, trackingBranch.shortName.UTF8String);
+  int result = GIT_ENOTFOUND;
+  if (trackingBranch.branchType == GTBranchTypeRemote) {
+    result = git_branch_set_upstream(self.reference.git_reference, [trackingBranch.name stringByReplacingOccurrencesOfString:[GTBranch remoteNamePrefix] withString:@""].UTF8String);
+	} else {
+		result = git_branch_set_upstream(self.reference.git_reference, trackingBranch.shortName.UTF8String);
+	}
 	if (result != GIT_OK) {
 		if (error != NULL) *error = [NSError git_errorFor:result description:@"Failed to update tracking branch for %@", self];
 		return NO;

--- a/ObjectiveGit/GTRepository+RemoteOperations.h
+++ b/ObjectiveGit/GTRepository+RemoteOperations.h
@@ -75,4 +75,17 @@ extern NSString *const GTRepositoryRemoteOptionsCredentialProvider;
 /// will point to an error describing what happened).
 - (BOOL)pushBranches:(NSArray *)branches toRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error progress:(void (^)(unsigned int current, unsigned int total, size_t bytes, BOOL *stop))progressBlock;
 
+/// Delete a remote branch
+///
+/// branch        - The branch to push. Must not be nil.
+/// remote        - The remote to push to. Must not be nil.
+/// options       - Options applied to the push operation. Can be NULL.
+///                 Recognized options are:
+///                 `GTRepositoryRemoteOptionsCredentialProvider`
+/// error         - The error if one occurred. Can be NULL.
+/// progressBlock - An optional callback for monitoring progress.
+///
+/// Returns YES if the push was successful, NO otherwise (and `error`, if provided,
+/// will point to an error describing what happened).
+- (BOOL)deleteBranch:(GTBranch *)branch fromRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error progress:(void (^)(unsigned int current, unsigned int total, size_t bytes, BOOL *stop))progressBlock;
 @end

--- a/ObjectiveGit/GTRepository+RemoteOperations.m
+++ b/ObjectiveGit/GTRepository+RemoteOperations.m
@@ -196,6 +196,16 @@ int GTFetchHeadEntriesCallback(const char *ref_name, const char *remote_url, con
 	return [self pushRefspecs:refspecs toRemote:remote withOptions:options error:error progress:progressBlock];
 }
 
+#pragma mark - Deletion (Public)
+- (BOOL)deleteBranch:(GTBranch *)branch fromRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error progress:(GTRemotePushTransferProgressBlock)progressBlock {
+		NSParameterAssert(branch != nil);
+		NSParameterAssert(remote != nil);
+		
+		NSArray *refspecs = @[[NSString stringWithFormat:@":refs/heads/%@", branch.shortName]];
+		
+		return [self pushRefspecs:refspecs toRemote:remote withOptions:options error:error progress:progressBlock];
+}
+
 #pragma mark - Push (Private)
 
 - (BOOL)pushRefspecs:(NSArray *)refspecs toRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error progress:(GTRemotePushTransferProgressBlock)progressBlock {

--- a/ObjectiveGitTests/GTBranchSpec.m
+++ b/ObjectiveGitTests/GTBranchSpec.m
@@ -228,6 +228,37 @@ describe(@"-updateTrackingBranch:error:", ^{
 		expect(trackingBranch).to(beNil());
 		expect(@(success)).to(beTruthy());
 	});
+		
+  it(@"should set a remote tracking branch without branches amount change", ^{
+	  GTRepository *repository = self.testAppForkFixtureRepository;
+		expect(repository).notTo(beNil());
+			
+		NSError *error = nil;
+		BOOL success = NO;
+		GTBranch *remoteBranch = [repository lookUpBranchWithName:@"github/BranchC" type:GTBranchTypeRemote success:&success error:&error];
+		expect(remoteBranch).notTo(beNil());
+		expect(error).to(beNil());
+			
+		NSArray *beforeBranches = [repository branches:&error];
+		expect(error).to(beNil());
+
+		GTBranch *localBranch = [repository createBranchNamed:remoteBranch.shortName fromOID:remoteBranch.OID message:nil error:&error];
+		expect(localBranch).notTo(beNil());
+		expect(error).to(beNil());
+			
+		NSArray *inBranches = [repository branches:&error];
+		expect(error).to(beNil());
+
+		[localBranch updateTrackingBranch:remoteBranch error:&error];
+		expect(error).to(beNil());
+			
+		NSArray *afterBranches = [repository branches:&error];
+		expect(error).to(beNil());
+		
+		expect(@(beforeBranches.count + 1)).to(equal(@(inBranches.count)));
+		expect(@(beforeBranches.count)).to(equal(@(afterBranches.count)));
+		
+	});
 });
 
 // TODO: Test branch renaming, branch upstream


### PR DESCRIPTION
### Modified
- `- (BOOL)updateTrackingBranch:(GTBranch *)trackingBranch error:(NSError **)error`

The original implement of this method wrongly considered remote tracking branch as local branch and added `remote = .` to `.git/config` which supposed to be `remote = <remote_name>`. This was caused by a wrong parameter objective-git used to pass to underlying method. 
A test case is added to `GTBranchSpec.m`.
### Added
- `- (BOOL)deleteBranch:(GTBranch *)branch fromRemote:(GTRemote *)remote withOptions:(NSDictionary *)options error:(NSError **)error progress:(void (^)(unsigned int current, unsigned int total, size_t bytes, BOOL *stop))progressBlock;`

This Method added unpublish support for branches like GitHub client did, it does a `git push <remote_name> :<dest>` action using the objective-git private push method.  
